### PR TITLE
scripts I used to prepare the UDv2 release

### DIFF
--- a/prepare-UDv2.sh
+++ b/prepare-UDv2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+IN=ro-ud-racai-uaic-9522-ttl.conllu
+
+# Check prerequisities
+[ -f $IN ] || { echo "$IN is missing, ask Radu"; exit 1; }
+udapy -h >/dev/null || { echo "udapy is not installed, see https://github.com/udapi/udapi-python"; exit 1; }
+
+#rm -rf sections; mkdir sections; cd sections
+#cat ../$IN | sed 's/^#/# newdoc id =/' | udapy read.Conllu split_docs=1 write.Conllu docname_as_file=1 print_text=0 print_sent_id=0
+
+./split-UDv2.pl $IN
+for a in train dev test; do
+    echo -ne "$a tokens\t"
+    grep '^[0-9]' ro-ud-$a.conllu | wc -l
+done
+
+SCENARIO="ud.ro.SetSpaceAfter ud.Convert1to2 ud.ro.FixNeg"
+for a in train dev test; do
+    mv ro-ud-$a.conllu v1-ro-ud-$a.conllu
+    udapy -s $SCENARIO util.Eval bundle="bundle.bundle_id = '$a-'+bundle.bundle_id" < v1-ro-ud-$a.conllu > ro-ud-$a.conllu
+done
+
+for a in train dev test; do
+    udapy -HAMC ud.MarkBugs < ro-ud-$a.conllu > bugs-$a.html
+done

--- a/split-UDv2.pl
+++ b/split-UDv2.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use feature 'say';
+
+my $TEST_RATIO = 0.075;
+my (@data, $docname);
+open my $TEST, '>', 'ro-ud-test.conllu';
+open my $DEV, '>', 'ro-ud-dev.conllu';
+open my $TRAIN, '>', 'ro-ud-train.conllu';
+
+sub flush {
+    my ($header) = @_;
+    my $min_lines = int(@data * $TEST_RATIO);
+    my $printed = 0;
+    say $DEV $header;
+    say $DEV $data[$printed++] while $printed < $min_lines or $data[$printed-1] ne '';
+    say $TEST $header;
+    say $TEST $data[$printed++] while $printed < 2*$min_lines or $data[$printed-1] ne '';
+    say $TRAIN $header;
+    say $TRAIN $data[$printed++] while $printed < @data;
+    @data = ();
+}
+
+while (<>){
+    chomp;
+    if (/^# (.+)/) {
+        flush("# newdoc id = $docname") if defined $docname;
+        $docname = $1;
+    } else {
+        push @data, $_;
+    }
+}
+flush("# newdoc id = $docname");
+close $DEV;
+close $TEST;
+close $TRAIN;


### PR DESCRIPTION
The `prepare-UDv2.sh` script
* splits train/test/dev and stores it in v1.4 style (could be applied also to the original conllx) using `split-UDv2.pl`
* converts the three files to v2.0 style using Udapi